### PR TITLE
Icons to expose/hide saved sessions + controls accessible by keyboard #1186

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -336,6 +336,9 @@ a.historyLink:hover {
   cursor: pointer;
   margin: 0 10px 0 -3px;
 }
+.icon-minus-squared-alt ~ .groupLink {
+  visibility: visible;
+}
 .sessionContents div:last-child {
   padding-bottom: 10px;
 }

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -120,6 +120,12 @@
       element.onclick = func;
     }
   }
+  
+  function addKeyDownListenerToElement (element, func) {
+	if (element) {
+	  element.onkeydown = func;
+	}
+  }
 
   function createSessionElement(session) {
     var sessionEl = historyItems.createSessionHtml(session, true);
@@ -128,6 +134,14 @@
       sessionEl.getElementsByClassName('sessionIcon')[0],
       function() {
         toggleSession(sessionEl, session.sessionId); //async. unhandled promise
+      }
+    );
+	addKeyDownListenerToElement(
+      sessionEl.getElementsByClassName('sessionIcon')[0],
+      function(event) {
+		if(event.keyCode === 13) {
+			toggleSession(sessionEl, session.sessionId); //async. unhandled promise
+		}
       }
     );
     addClickListenerToElement(

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -122,9 +122,9 @@
   }
   
   function addKeyDownListenerToElement (element, func) {
-	if (element) {
-	  element.onkeydown = func;
-	}
+    if (element) {
+      element.onkeydown = func;
+    }
   }
 
   function createSessionElement(session) {
@@ -136,12 +136,12 @@
         toggleSession(sessionEl, session.sessionId); //async. unhandled promise
       }
     );
-	addKeyDownListenerToElement(
+    addKeyDownListenerToElement(
       sessionEl.getElementsByClassName('sessionIcon')[0],
       function(event) {
-		if(event.keyCode === 13) {
-			toggleSession(sessionEl, session.sessionId); //async. unhandled promise
-		}
+        if(event.keyCode === 13) {
+	  toggleSession(sessionEl, session.sessionId); //async. unhandled promise
+	}
       }
     );
     addClickListenerToElement(

--- a/src/js/historyItems.js
+++ b/src/js/historyItems.js
@@ -57,7 +57,7 @@ var historyItems = (function(global) {
 
     sessionIcon = createEl('i', {
       class: 'sessionIcon icon icon-plus-squared-alt',
-	  tabindex: 0
+      tabindex: 0
     });
 
     sessionDiv = createEl('div', {

--- a/src/js/historyItems.js
+++ b/src/js/historyItems.js
@@ -57,6 +57,7 @@ var historyItems = (function(global) {
 
     sessionIcon = createEl('i', {
       class: 'sessionIcon icon icon-plus-squared-alt',
+	  tabindex: 0
     });
 
     sessionDiv = createEl('div', {


### PR DESCRIPTION
I don't contribute often so excuse me if I'm not following the protocol for pull requests. The original issue can be found here: https://github.com/greatsuspender/thegreatsuspender/issues/1186