### PR TITLE
Remove popup opacity transition

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -43,10 +43,6 @@ a {
   outline: none;
   color: #3477db;
 }
-#popupContent {
-  opacity: 0;
-  transition: opacity 200ms ease;
-}
 #statusDetail a {
   color: #ffffff;
 }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -261,9 +261,6 @@
     if (theme === 'dark') {
       document.body.classList.add('dark');
     }
-    setTimeout(function() {
-      document.getElementById('popupContent').style.opacity = 1;
-    }, 200);
   }
 
   function addClickHandlers() {


### PR DESCRIPTION
Hi! This is a great extension, thanks for making it.

The only thing that has been bugging me a bit is that the popup contents take a very long time to appear. Honestly this may be a bit OCD on my side, but I don't like artificial slowness like this. Yes, I also turn off smooth scrolling whenever I use Firefox. I just think it makes everything feel laggy.

Anyway, I couldn't find any technical reason why it takes half a second for the contents to appear. It seems to work well for me with it removed. I hope you consider accepting this change.

Thank you!